### PR TITLE
try with 14.2.1

### DIFF
--- a/components/auth-components.tsx
+++ b/components/auth-components.tsx
@@ -1,34 +1,28 @@
-import { signIn, signOut } from "auth"
-import { Button } from "./ui/button"
+"use client";
+
+import { signIn, signOut } from "next-auth/react";
+import { Button } from "./ui/button";
 
 export function SignIn({
   provider,
   ...props
 }: { provider?: string } & React.ComponentPropsWithRef<typeof Button>) {
   return (
-    <form
-      action={async () => {
-        "use server"
-        await signIn(provider)
-      }}
-    >
-      <Button {...props}>Sign In</Button>
-    </form>
-  )
+    <Button {...props} onClick={() => signIn(provider)}>
+      Sign In
+    </Button>
+  );
 }
 
 export function SignOut(props: React.ComponentPropsWithRef<typeof Button>) {
   return (
-    <form
-      action={async () => {
-        "use server"
-        await signOut()
-      }}
-      className="w-full"
+    <Button
+      variant="ghost"
+      className="w-full p-0"
+      onClick={() => signOut()}
+      {...props}
     >
-      <Button variant="ghost" className="w-full p-0" {...props}>
-        Sign Out
-      </Button>
-    </form>
-  )
+      Sign Out
+    </Button>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.274.0",
-    "next": "14.1.4",
+    "next": "14.2.1",
     "next-auth": "beta",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Instead of using signIn from auth.ts
```
import { signIn } from '@/app/auth';


export function SignIn({ provider, ...props }: { provider?: string } & React.ComponentPropsWithRef<typeof Button>) {
  return (
    <form
      action={async () => {
        'use server';
        await signIn(provider);
      }}
    >
      <Button {...props}>Sign In</Button>
    </form>
  );
}

```


use signin from next-auth/react

```
"use client";
import { signIn } from "next-auth/react";

export function SignIn({
  provider,
  ...props
}: { provider?: string } & React.ComponentPropsWithRef<typeof Button>) {
  return (
    <Button {...props} onClick={() => signIn(provider)}>
      Sign In
    </Button>
  );
}
```


